### PR TITLE
Fix exports map to match actual tsdown output

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,18 @@
     "url": "git+https://github.com/0x80/get-or-throw.git"
   },
   "type": "module",
-  "main": "dist/index.cjs",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "publishConfig": {


### PR DESCRIPTION
Fixes #6

The tsdown upgrade to v0.21.7 changed the default ESM output extension from `.js` to `.mjs`, but the `exports` field was not updated to match. This caused `ERR_MODULE_NOT_FOUND` when importing the package as ESM.

Updates the exports map to point to the actual filenames (`index.mjs`, `index.cjs`, `index.d.mts`, `index.d.cts`) and adds proper conditional `types` entries for both import and require conditions.

Scope: package
Visibility: user-facing